### PR TITLE
Feature/t value comparison

### DIFF
--- a/ClippingBezier/UIBezierPath+Clipping.mm
+++ b/ClippingBezier/UIBezierPath+Clipping.mm
@@ -308,6 +308,8 @@ static NSInteger segmentCompareCount = 0;
             CGPoint lastLoc = lastInter.location1;
             CGPoint interLoc2 = intersection.location2;
             CGPoint lastLoc2 = lastInter.location2;
+
+
             if (isDistinctIntersection) {
                 if ((ABS(interLoc.x - lastLoc.x) < kUIBezierClosenessPrecision &&
                      ABS(interLoc.y - lastLoc.y) < kUIBezierClosenessPrecision) ||
@@ -322,11 +324,20 @@ static NSInteger segmentCompareCount = 0;
                     BOOL closeLocation1 = [lastInter isCloseToIntersection:intersection withPrecision:kUIBezierClosenessPrecision];
                     BOOL closeLocation2 = [[lastInter flipped] isCloseToIntersection:[intersection flipped] withPrecision:kUIBezierClosenessPrecision];
 
-                    if (closeLocation1 != closeLocation2) {
-                        NSLog(@"gotcha");
-                    }
-
                     isDistinctIntersection = !closeLocation1 || !closeLocation2;
+                }
+                // if we still think it's distinct, then also compare the effective t-values
+                if (isDistinctIntersection) {
+                    CGFloat closeT = [self effectiveTDistanceFromElement:[lastInter elementIndex1]
+                                                               andTValue:[lastInter tValue1]
+                                                               toElement:[intersection elementIndex1]
+                                                               andTValue:[intersection tValue1]];
+
+                    if (ABS(closeT) < kUIBezierClippingPrecision) {
+                        // The points are not actually very far apart at all in terms of t-distance. only bother to check
+                        // pixel closeness if our t-values are at all far apart.
+                        isDistinctIntersection = NO;
+                    }
                 }
             }
             if (isDistinctIntersection) {

--- a/ClippingBezier/UIBezierPath+GeometryExtras.h
+++ b/ClippingBezier/UIBezierPath+GeometryExtras.h
@@ -18,4 +18,9 @@
 
 - (CGPoint)pointOnPathAtElement:(NSInteger)elementIndex andTValue:(CGFloat)tVal;
 
+/// Path elements that do not change the location of the curve at all are considered 0 effective-t-distance. For instance,
+/// closing a path that has already arrived back at the moveTo location will have an effective-t-distance of 0 for any tValue
+/// in that closePath element. See the GeometryTests for examples.
+- (CGFloat)effectiveTDistanceFromElement:(NSInteger)elementIndex1 andTValue:(CGFloat)tVal1 toElement:(NSInteger)elementIndex2 andTValue:(CGFloat)tVal2;
+
 @end

--- a/ClippingBezier/UIBezierPath+GeometryExtras.m
+++ b/ClippingBezier/UIBezierPath+GeometryExtras.m
@@ -254,5 +254,61 @@ CGPoint NearestPointOnLine(CGPoint p, CGPoint a, CGPoint b)
     return left[3];
 }
 
+/// The method calculates the effective distance between two offsets in a path. MoveTo and Close path elements are coalesced when possible.
+/// Refer to the MMClippingBezierGeometryTests for detailed example behavior.
+- (CGFloat)effectiveTDistanceFromElement:(NSInteger)elementIndex1 andTValue:(CGFloat)tVal1 toElement:(NSInteger)elementIndex2 andTValue:(CGFloat)tVal2
+{
+    NSRange rng1 = [self subpathRangeForElement:elementIndex1];
+    NSRange rng2 = [self subpathRangeForElement:elementIndex2];
+
+    if (!NSEqualRanges(rng1, rng2)) {
+        return CGFLOAT_MAX;
+    }
+
+    CGFloat maxPossibleT = [self helperTDistanceFromElement:rng1.location andTValue:0 toElement:NSMaxRange(rng1) - 1 andTValue:1];
+    CGFloat actualT = [self helperTDistanceFromElement:elementIndex1 andTValue:tVal1 toElement:elementIndex2 andTValue:tVal2];
+
+    if ([self isClosed]) {
+        BOOL isNeg = signbit(actualT);
+        // calculate how far it would be to travel backwards
+        CGFloat backwardDist = (maxPossibleT - ABS(actualT));
+        backwardDist = isNeg ? backwardDist : -backwardDist;
+        // swap the distance if going backwards would be faster
+        return ABS(backwardDist) >= ABS(actualT) ? actualT : backwardDist;
+    } else {
+        return actualT;
+    }
+}
+
+- (CGFloat)helperTDistanceFromElement:(NSInteger)elementIndex1 andTValue:(CGFloat)tVal1 toElement:(NSInteger)elementIndex2 andTValue:(CGFloat)tVal2
+{
+    NSRange rng1 = [self subpathRangeForElement:elementIndex1];
+    NSRange rng2 = [self subpathRangeForElement:elementIndex2];
+
+    if (!NSEqualRanges(rng1, rng2)) {
+        return CGFLOAT_MAX;
+    }
+
+    if (elementIndex1 > elementIndex2 || (elementIndex1 == elementIndex2 && tVal1 > tVal2)) {
+        return -[self helperTDistanceFromElement:elementIndex2 andTValue:tVal2 toElement:elementIndex1 andTValue:tVal1];
+    }
+
+    if (![self changesPositionDuringElement:elementIndex1]) {
+        tVal1 = 0.0;
+    }
+    if (![self changesPositionDuringElement:elementIndex2]) {
+        tVal2 = 0.0;
+    }
+
+    CGFloat diff = tVal2 - tVal1;
+
+    for (NSInteger index = elementIndex1; index < elementIndex2; index++) {
+        if ([self changesPositionDuringElement:index]) {
+            diff += 1;
+        }
+    }
+
+    return diff;
+}
 
 @end

--- a/ClippingBezier/UIBezierPath+Trimming.m
+++ b/ClippingBezier/UIBezierPath+Trimming.m
@@ -375,7 +375,13 @@
             break;
     }
 
-    return atan2f(point2.y - point1.y, point2.x - point1.x) + M_PI;
+    CGFloat ret = atan2f(point2.y - point1.y, point2.x - point1.x) + M_PI;
+
+    if (ret > M_PI) {
+        ret -= 2.0 * M_PI;
+    }
+
+    return ret;
 }
 
 - (CGFloat)tangentAtStartOfSubpath:(NSInteger)index

--- a/ClippingBezierTests/MMClippingBezierGeometryTest.m
+++ b/ClippingBezierTests/MMClippingBezierGeometryTest.m
@@ -49,5 +49,417 @@
     XCTAssertEqual([self round:p.y to:6], 287.768800, @"point is correct");
 }
 
+- (void)testSubpathRangeForIndexClosePath
+{
+    NSRange key = NSMakeRange(0, 4);
+    UIBezierPath *path = [UIBezierPath bezierPath];
+    [path moveToPoint:CGPointMake(0, 0)];
+    [path addLineToPoint:CGPointMake(0, 100)];
+    [path addLineToPoint:CGPointMake(100, 0)];
+    [path closePath];
+
+    NSRange rng = [path subpathRangeForElement:0];
+
+    XCTAssertEqual(rng.location, key.location);
+    XCTAssertEqual(rng.length, key.length);
+
+    rng = [path subpathRangeForElement:1];
+
+    XCTAssertEqual(rng.location, key.location);
+    XCTAssertEqual(rng.length, key.length);
+
+    rng = [path subpathRangeForElement:2];
+
+    XCTAssertEqual(rng.location, key.location);
+    XCTAssertEqual(rng.length, key.length);
+
+    rng = [path subpathRangeForElement:3];
+
+    XCTAssertEqual(rng.location, key.location);
+    XCTAssertEqual(rng.length, key.length);
+}
+
+- (void)testSubpathRangeForIndexOpenPath
+{
+    NSRange key = NSMakeRange(0, 3);
+    UIBezierPath *path = [UIBezierPath bezierPath];
+    [path moveToPoint:CGPointMake(0, 0)];
+    [path addLineToPoint:CGPointMake(0, 100)];
+    [path addLineToPoint:CGPointMake(100, 0)];
+
+    NSRange rng = [path subpathRangeForElement:0];
+
+    XCTAssertEqual(rng.location, key.location);
+    XCTAssertEqual(rng.length, key.length);
+
+    rng = [path subpathRangeForElement:1];
+
+    XCTAssertEqual(rng.location, key.location);
+    XCTAssertEqual(rng.length, key.length);
+
+    rng = [path subpathRangeForElement:2];
+
+    XCTAssertEqual(rng.location, key.location);
+    XCTAssertEqual(rng.length, key.length);
+}
+
+- (void)testSubpathRangeForIndexMultiplePaths
+{
+    NSRange key1 = NSMakeRange(0, 3);
+    NSRange key2 = NSMakeRange(3, 3);
+    UIBezierPath *path = [UIBezierPath bezierPath];
+    [path moveToPoint:CGPointMake(0, 0)];
+    [path addLineToPoint:CGPointMake(0, 100)];
+    [path addLineToPoint:CGPointMake(100, 0)];
+    [path moveToPoint:CGPointMake(0, 0)];
+    [path addLineToPoint:CGPointMake(0, 100)];
+    [path addLineToPoint:CGPointMake(100, 0)];
+
+    NSRange rng = [path subpathRangeForElement:0];
+
+    XCTAssertEqual(rng.location, key1.location);
+    XCTAssertEqual(rng.length, key1.length);
+
+    rng = [path subpathRangeForElement:1];
+
+    XCTAssertEqual(rng.location, key1.location);
+    XCTAssertEqual(rng.length, key1.length);
+
+    rng = [path subpathRangeForElement:2];
+
+    XCTAssertEqual(rng.location, key1.location);
+    XCTAssertEqual(rng.length, key1.length);
+
+    rng = [path subpathRangeForElement:3];
+
+    XCTAssertEqual(rng.location, key2.location);
+    XCTAssertEqual(rng.length, key2.length);
+
+    rng = [path subpathRangeForElement:4];
+
+    XCTAssertEqual(rng.location, key2.location);
+    XCTAssertEqual(rng.length, key2.length);
+
+    rng = [path subpathRangeForElement:5];
+
+    XCTAssertEqual(rng.location, key2.location);
+    XCTAssertEqual(rng.length, key2.length);
+}
+
+- (void)testSubpathRangeForIndexAdjacentMoveTo
+{
+    UIBezierPath *path = [UIBezierPath bezierPath];
+    [path moveToPoint:CGPointMake(0, 0)];
+    [path moveToPoint:CGPointMake(0, 0)];
+    [path moveToPoint:CGPointMake(0, 0)];
+
+    NSRange rng = [path subpathRangeForElement:0];
+
+    XCTAssertEqual(rng.location, 0);
+    XCTAssertEqual(rng.length, 1);
+
+    rng = [path subpathRangeForElement:1];
+
+    XCTAssertEqual(rng.location, 1);
+    XCTAssertEqual(rng.length, 1);
+
+    rng = [path subpathRangeForElement:2];
+
+    XCTAssertEqual(rng.location, 2);
+    XCTAssertEqual(rng.length, 1);
+}
+
+- (void)testSubpathRangeForIndexTinyPaths
+{
+    UIBezierPath *path = [UIBezierPath bezierPath];
+    [path moveToPoint:CGPointMake(0, 0)];
+    [path closePath];
+    [path moveToPoint:CGPointMake(0, 0)];
+    [path closePath];
+    [path moveToPoint:CGPointMake(0, 0)];
+    [path closePath];
+
+    NSRange rng = [path subpathRangeForElement:0];
+
+    XCTAssertEqual(rng.location, 0);
+    XCTAssertEqual(rng.length, 2);
+
+    rng = [path subpathRangeForElement:1];
+
+    XCTAssertEqual(rng.location, 0);
+    XCTAssertEqual(rng.length, 2);
+
+    rng = [path subpathRangeForElement:2];
+
+    XCTAssertEqual(rng.location, 2);
+    XCTAssertEqual(rng.length, 2);
+
+    rng = [path subpathRangeForElement:3];
+
+    XCTAssertEqual(rng.location, 2);
+    XCTAssertEqual(rng.length, 2);
+
+    rng = [path subpathRangeForElement:4];
+
+    XCTAssertEqual(rng.location, 4);
+    XCTAssertEqual(rng.length, 2);
+
+    rng = [path subpathRangeForElement:5];
+
+    XCTAssertEqual(rng.location, 4);
+    XCTAssertEqual(rng.length, 2);
+}
+
+- (void)testTValueDistanceSingleElement
+{
+    UIBezierPath *path = [UIBezierPath bezierPath];
+    [path moveToPoint:CGPointMake(0, 0)];
+
+    CGFloat dist = [path effectiveTDistanceFromElement:0 andTValue:0 toElement:0 andTValue:1];
+    XCTAssertEqual(dist, 0);
+
+    dist = [path effectiveTDistanceFromElement:0 andTValue:0 toElement:0 andTValue:0];
+    XCTAssertEqual(dist, 0);
+
+    dist = [path effectiveTDistanceFromElement:0 andTValue:1 toElement:0 andTValue:0];
+    XCTAssertEqual(dist, 0);
+}
+
+- (void)testTValueDistanceTwoElements
+{
+    UIBezierPath *path = [UIBezierPath bezierPath];
+    [path moveToPoint:CGPointMake(0, 0)];
+    [path closePath];
+
+    CGFloat dist = [path effectiveTDistanceFromElement:0 andTValue:0 toElement:0 andTValue:1];
+    XCTAssertEqual(dist, 0);
+
+    dist = [path effectiveTDistanceFromElement:0 andTValue:0 toElement:1 andTValue:0];
+    XCTAssertEqual(dist, 0);
+
+    dist = [path effectiveTDistanceFromElement:1 andTValue:0 toElement:0 andTValue:0];
+    XCTAssertEqual(dist, 0);
+
+    dist = [path effectiveTDistanceFromElement:0 andTValue:1 toElement:0 andTValue:0];
+    XCTAssertEqual(dist, 0);
+}
+
+- (void)testTValueDistanceThroughLines
+{
+    UIBezierPath *path = [UIBezierPath bezierPath];
+    [path moveToPoint:CGPointMake(0, 0)];
+    [path addLineToPoint:CGPointMake(0, 100)];
+    [path addLineToPoint:CGPointMake(100, 0)];
+    [path addLineToPoint:CGPointMake(0, 0)];
+    [path closePath];
+
+    CGFloat dist = [path effectiveTDistanceFromElement:0 andTValue:0 toElement:1 andTValue:1];
+    XCTAssertEqual(dist, 1);
+
+    dist = [path effectiveTDistanceFromElement:1 andTValue:0.25 toElement:2 andTValue:0.5];
+    XCTAssertEqual(dist, 1.25);
+
+    // quicker to go backwards than forwards through 2.25 distance
+    dist = [path effectiveTDistanceFromElement:1 andTValue:0.25 toElement:3 andTValue:0.5];
+    XCTAssertEqual(dist, -0.75);
+}
+
+- (void)testTValueDistanceBackwardThroughLines
+{
+    UIBezierPath *path = [UIBezierPath bezierPath];
+    [path moveToPoint:CGPointMake(0, 0)];
+    [path addLineToPoint:CGPointMake(0, 100)];
+    [path addLineToPoint:CGPointMake(100, 0)];
+    [path addLineToPoint:CGPointMake(0, 0)];
+    [path closePath];
+
+    CGFloat dist = [path effectiveTDistanceFromElement:1 andTValue:1 toElement:0 andTValue:0];
+    XCTAssertEqual(dist, -1);
+
+    dist = [path effectiveTDistanceFromElement:2 andTValue:0.5 toElement:1 andTValue:0.25];
+    XCTAssertEqual(dist, -1.25);
+
+    dist = [path effectiveTDistanceFromElement:3 andTValue:0.5 toElement:1 andTValue:0.25];
+    XCTAssertEqual(dist, 0.75);
+
+    dist = [path effectiveTDistanceFromElement:1 andTValue:0 toElement:3 andTValue:1];
+    XCTAssertEqual(dist, 0.0);
+
+    dist = [path effectiveTDistanceFromElement:3 andTValue:1 toElement:1 andTValue:0];
+    XCTAssertEqual(dist, 0.0);
+}
+
+- (void)testTValueDistanceClose1
+{
+    UIBezierPath *path = [UIBezierPath bezierPath];
+    [path moveToPoint:CGPointMake(0, 0)];
+    [path addLineToPoint:CGPointMake(0, 100)];
+    [path addLineToPoint:CGPointMake(100, 0)];
+    [path closePath];
+
+    CGFloat dist = [path effectiveTDistanceFromElement:0 andTValue:0 toElement:3 andTValue:1];
+    XCTAssertEqual(dist, 0);
+
+    dist = [path effectiveTDistanceFromElement:3 andTValue:1 toElement:0 andTValue:0];
+    XCTAssertEqual(dist, 0);
+
+    dist = [path effectiveTDistanceFromElement:3 andTValue:0 toElement:0 andTValue:0];
+    XCTAssertEqual(dist, 1);
+
+    dist = [path effectiveTDistanceFromElement:3 andTValue:1 toElement:0 andTValue:.5];
+    XCTAssertEqual(dist, 0);
+
+    dist = [path effectiveTDistanceFromElement:1 andTValue:0 toElement:2 andTValue:1];
+    XCTAssertEqual(dist, -1.0);
+
+    dist = [path effectiveTDistanceFromElement:2 andTValue:1 toElement:1 andTValue:0];
+    XCTAssertEqual(dist, 1.0);
+
+    dist = [path effectiveTDistanceFromElement:3 andTValue:0.1 toElement:0 andTValue:.5];
+    XCTAssertEqualWithAccuracy(dist, 0.9, 0.000001);
+
+    dist = [path effectiveTDistanceFromElement:0 andTValue:0.5 toElement:3 andTValue:0.1];
+    XCTAssertEqualWithAccuracy(dist, -0.9, 0.000001);
+}
+
+- (void)testTValueDistanceClose2
+{
+    UIBezierPath *path = [UIBezierPath bezierPath];
+    [path moveToPoint:CGPointMake(0, 0)];
+    [path addLineToPoint:CGPointMake(0, 100)];
+    [path addLineToPoint:CGPointMake(0, 0)];
+    [path closePath];
+
+    CGFloat dist = [path effectiveTDistanceFromElement:0 andTValue:0 toElement:3 andTValue:1];
+    XCTAssertEqual(dist, 0);
+
+    dist = [path effectiveTDistanceFromElement:3 andTValue:1 toElement:0 andTValue:0];
+    XCTAssertEqual(dist, 0);
+
+    dist = [path effectiveTDistanceFromElement:3 andTValue:0 toElement:0 andTValue:0];
+    XCTAssertEqual(dist, 0);
+
+    dist = [path effectiveTDistanceFromElement:3 andTValue:1 toElement:0 andTValue:.5];
+    XCTAssertEqual(dist, 0);
+
+    dist = [path effectiveTDistanceFromElement:2 andTValue:0 toElement:0 andTValue:0];
+    XCTAssertEqual(dist, -1);
+
+    dist = [path effectiveTDistanceFromElement:2 andTValue:1 toElement:0 andTValue:.5];
+    XCTAssertEqual(dist, 0);
+
+    dist = [path effectiveTDistanceFromElement:1 andTValue:0.5 toElement:2 andTValue:.5];
+    XCTAssertEqual(dist, 1);
+
+    dist = [path effectiveTDistanceFromElement:3 andTValue:0.1 toElement:0 andTValue:.5];
+    XCTAssertEqual(dist, 0);
+
+    dist = [path effectiveTDistanceFromElement:0 andTValue:0.5 toElement:3 andTValue:0.1];
+    XCTAssertEqual(dist, 0);
+}
+
+- (void)testTValueDistanceClose3
+{
+    UIBezierPath *path = [UIBezierPath bezierPath];
+    [path moveToPoint:CGPointMake(0, 0)];
+    [path addLineToPoint:CGPointMake(0, 100)];
+    [path addLineToPoint:CGPointMake(0, 0)];
+    [path closePath];
+
+    CGFloat dist = [path effectiveTDistanceFromElement:1 andTValue:0.005 toElement:2 andTValue:0.995];
+    XCTAssertEqualWithAccuracy(dist, -0.01, 0.000001);
+
+    dist = [path effectiveTDistanceFromElement:2 andTValue:0.995 toElement:1 andTValue:0.005];
+    XCTAssertEqualWithAccuracy(dist, 0.01, 0.000001);
+
+    dist = [path effectiveTDistanceFromElement:1 andTValue:0.995 toElement:2 andTValue:0.005];
+    XCTAssertEqualWithAccuracy(dist, 0.01, 0.000001);
+
+    dist = [path effectiveTDistanceFromElement:2 andTValue:0.005 toElement:1 andTValue:0.995];
+    XCTAssertEqualWithAccuracy(dist, -0.01, 0.000001);
+}
+
+- (void)testTValueIgnoreLineSegment
+{
+    UIBezierPath *path = [UIBezierPath bezierPath];
+    [path moveToPoint:CGPointMake(0, 0)]; // 0: ignore this element
+    [path addLineToPoint:CGPointMake(0, 100)]; // 1: [0, 100]
+    [path addLineToPoint:CGPointMake(0, 200)]; // 2: [100, 200]
+    [path addLineToPoint:CGPointMake(0, 300)]; // 3: [200, 300]
+    [path addLineToPoint:CGPointMake(0, 300)]; // 4: ignore this element
+    [path addLineToPoint:CGPointMake(0, 400)]; // 5: [300, 400]
+    [path addLineToPoint:CGPointMake(0, 0)]; // 6: [400, 0]
+    [path closePath];
+
+    CGFloat dist = [path effectiveTDistanceFromElement:1 andTValue:0.005 toElement:2 andTValue:0.995];
+    XCTAssertEqualWithAccuracy(dist, 1.99, 0.000001);
+
+    dist = [path effectiveTDistanceFromElement:2 andTValue:0 toElement:3 andTValue:0];
+    XCTAssertEqualWithAccuracy(dist, 1, 0.000001);
+
+    dist = [path effectiveTDistanceFromElement:2 andTValue:0 toElement:3 andTValue:1];
+    XCTAssertEqualWithAccuracy(dist, 2, 0.000001);
+
+    dist = [path effectiveTDistanceFromElement:2 andTValue:0 toElement:4 andTValue:0];
+    XCTAssertEqualWithAccuracy(dist, 2, 0.000001);
+
+    // skip the element since it doesn't move the point
+    dist = [path effectiveTDistanceFromElement:2 andTValue:0 toElement:4 andTValue:1];
+    XCTAssertEqualWithAccuracy(dist, 2, 0.000001);
+}
+
+- (void)testTValueIgnoreLineSegment2
+{
+    UIBezierPath *path = [UIBezierPath bezierPath];
+    [path moveToPoint:CGPointMake(0, 0)]; // 0: ignore this element
+    [path addLineToPoint:CGPointMake(0, 100)]; // 1: [0, 100]
+    [path addLineToPoint:CGPointMake(0, 200)]; // 2: [100, 200]
+    [path addLineToPoint:CGPointMake(0, 300)]; // 3: [200, 300]
+    [path addLineToPoint:CGPointMake(0, 300)]; // 4: ignore this element
+    [path addLineToPoint:CGPointMake(0, 300)]; // 5: ignore this element
+    [path addLineToPoint:CGPointMake(0, 300)]; // 6: ignore this element
+    [path addLineToPoint:CGPointMake(0, 300)]; // 7: ignore this element
+    [path addLineToPoint:CGPointMake(0, 400)]; // 8: [300, 400]
+    [path addLineToPoint:CGPointMake(0, 0)]; // 9: [400, 0]
+    [path closePath];
+
+    CGFloat dist = [path effectiveTDistanceFromElement:4 andTValue:0.005 toElement:6 andTValue:0.995];
+    XCTAssertEqualWithAccuracy(dist, 0.0, 0.000001);
+
+    dist = [path effectiveTDistanceFromElement:3 andTValue:0.5 toElement:6 andTValue:0.95];
+    XCTAssertEqualWithAccuracy(dist, 0.5, 0.000001);
+}
+
+- (void)testTValueLoopBackwardClose
+{
+    UIBezierPath *path = [UIBezierPath bezierPath];
+    [path moveToPoint:CGPointMake(400, 300)];
+    [path addLineToPoint:CGPointMake(300, 400)];
+    [path addLineToPoint:CGPointMake(200, 300)];
+    [path addLineToPoint:CGPointMake(300, 200)];
+    [path addLineToPoint:CGPointMake(400, 300)];
+    [path closePath];
+
+    CGFloat dist = [path effectiveTDistanceFromElement:1 andTValue:0 toElement:4 andTValue:1];
+    XCTAssertEqual(dist, 0.0);
+
+    dist = [path effectiveTDistanceFromElement:4 andTValue:1 toElement:1 andTValue:0];
+    XCTAssertEqual(dist, 0.0);
+}
+
+- (void)testTValueClippingCase
+{
+    UIBezierPath *path = [UIBezierPath bezierPath];
+    [path moveToPoint:CGPointMake(400, 300)];
+    [path addCurveToPoint:CGPointMake(300, 400) controlPoint1:CGPointMake(400, 355.22847498) controlPoint2:CGPointMake(355.22847498, 400)];
+    [path addCurveToPoint:CGPointMake(200, 300) controlPoint1:CGPointMake(244.77152502, 400) controlPoint2:CGPointMake(200, 355.22847498)];
+    [path addCurveToPoint:CGPointMake(300, 200) controlPoint1:CGPointMake(200, 244.77152502) controlPoint2:CGPointMake(244.77152502, 200)];
+    [path addCurveToPoint:CGPointMake(400, 300) controlPoint1:CGPointMake(355.22847498, 200) controlPoint2:CGPointMake(400, 244.77152502)];
+    [path closePath];
+
+    CGFloat dist = [path effectiveTDistanceFromElement:4 andTValue:0.99999568124138771 toElement:1 andTValue:0.0000028883736617010538];
+    XCTAssertEqualWithAccuracy(dist, 0.000007, 0.000001);
+}
+
 
 @end

--- a/ClippingBezierTests/MMClippingBezierTodoTests.m
+++ b/ClippingBezierTests/MMClippingBezierTodoTests.m
@@ -145,6 +145,33 @@
     XCTAssertEqual([blueSegments count], (NSUInteger)2, @"correct number of segments");
 }
 
+- (void)testLineNearBoundary3
+{
+    // path is tangent that is 2pts long
+    // intersections are allowed to be .5 distnace away
+    // from each other, so max of 4 intersections might
+    // happen
+
+    UIBezierPath *shapePath = [UIBezierPath bezierPath];
+    [shapePath moveToPoint:CGPointMake(0.000000, 0.000000)];
+    [shapePath addLineToPoint:CGPointMake(768.000000, 0.000000)];
+    [shapePath addLineToPoint:CGPointMake(768.000000, 1024.000000)];
+    [shapePath addLineToPoint:CGPointMake(0.000000, 1024.000000)];
+    [shapePath closePath];
+
+    UIBezierPath *scissorPath = [UIBezierPath bezierPath];
+    [scissorPath moveToPoint:CGPointMake(478.500000, 1024.000000)];
+    [scissorPath addCurveToPoint:CGPointMake(484.000000, 1024.000000) controlPoint1:CGPointMake(480.562500, 1024.000000) controlPoint2:CGPointMake(481.937500, 1024.000000)];
+
+
+    BOOL beginsInside = NO;
+    NSArray *scissorToShapeIntersections = [scissorPath findIntersectionsWithClosedPath:shapePath andBeginsInside:&beginsInside];
+    NSArray *shapeToScissorIntersections = [shapePath findIntersectionsWithClosedPath:scissorPath andBeginsInside:&beginsInside];
+
+    XCTAssertEqual([scissorToShapeIntersections count], [shapeToScissorIntersections count], @"count of intersections matches");
+    XCTAssertEqual([scissorToShapeIntersections count], (NSUInteger)2, @"count of intersections matches");
+}
+
 #pragma mark - Segment Tests
 
 - (void)testReversedSquaredCircleIntersections

--- a/ClippingBezierTests/MMClippingBezierTrimmingTests.m
+++ b/ClippingBezierTests/MMClippingBezierTrimmingTests.m
@@ -86,7 +86,67 @@
     [path1 addLineToPoint:CGPointMake(10, 10)];
 
     CGFloat tangent = [path1 tangentAtStart];
-    XCTAssertEqual([self round:tangent to:6], (CGFloat)3.926991, "tangent is correct");
+    XCTAssertEqual([self round:tangent to:6], (CGFloat)-2.356195, "tangent is correct");
+}
+
+- (void)testStartEndTangent1
+{
+    // This is an example of a functional test case.
+
+    UIBezierPath *path1 = [UIBezierPath bezierPath];
+    [path1 moveToPoint:CGPointZero];
+    [path1 addLineToPoint:CGPointMake(10, 0)];
+
+    CGFloat tangent = [path1 tangentAtStart];
+    XCTAssertEqualWithAccuracy(tangent, M_PI, 0.000001);
+
+    tangent = [path1 tangentAtEnd];
+    XCTAssertEqualWithAccuracy(tangent, 0, 0.000001);
+}
+
+- (void)testStartEndTangent2
+{
+    // This is an example of a functional test case.
+
+    UIBezierPath *path1 = [UIBezierPath bezierPath];
+    [path1 moveToPoint:CGPointZero];
+    [path1 addLineToPoint:CGPointMake(0, 10)];
+
+    CGFloat tangent = [path1 tangentAtStart];
+    XCTAssertEqualWithAccuracy(tangent, -M_PI_2, 0.000001);
+
+    tangent = [path1 tangentAtEnd];
+    XCTAssertEqualWithAccuracy(tangent, M_PI_2, 0.000001);
+}
+
+- (void)testStartEndTangent3
+{
+    // This is an example of a functional test case.
+
+    UIBezierPath *path1 = [UIBezierPath bezierPath];
+    [path1 moveToPoint:CGPointZero];
+    [path1 addLineToPoint:CGPointMake(-10, 0)];
+
+    CGFloat tangent = [path1 tangentAtStart];
+    XCTAssertEqualWithAccuracy(tangent, 0, 0.000001);
+
+    tangent = [path1 tangentAtEnd];
+    XCTAssertEqualWithAccuracy(tangent, M_PI, 0.000001);
+}
+
+- (void)testStartEndTangent4
+{
+    // This is an example of a functional test case.
+
+    UIBezierPath *path1 = [UIBezierPath bezierPath];
+    [path1 moveToPoint:CGPointZero];
+    [path1 addLineToPoint:CGPointMake(0, -10)];
+
+    CGFloat tangent = [path1 tangentAtStart];
+    XCTAssertEqualWithAccuracy(tangent, M_PI_2, 0.000001);
+
+    tangent = [path1 tangentAtEnd];
+    XCTAssertEqualWithAccuracy(tangent, -M_PI_2, 0.000001);
 }
 
 - (void)testStartTangentOfSubpath
@@ -100,7 +160,7 @@
     [path1 addLineToPoint:CGPointMake(10, 10)];
 
     CGFloat tangent = [path1 tangentAtStartOfSubpath:1];
-    XCTAssertEqual([self round:tangent to:6], (CGFloat)3.926991, "tangent is correct");
+    XCTAssertEqual([self round:tangent to:6], (CGFloat)-2.356195, "tangent is correct");
 }
 
 - (void)testStartTangentOfSubpath2


### PR DESCRIPTION
Fixes a number of issues found when debugging the union test cases. One helpful thing is the new ability to calculate the 'effective t-value distance' between two points. Added quite a few test cases in `MMClippingBezierGeometryTest` to both verify and describe how it works.

```objective-c
- (void)testTValueIgnoreLineSegment2
{
    UIBezierPath *path = [UIBezierPath bezierPath];
    [path moveToPoint:CGPointMake(0, 0)]; // 0: ignore this element
    [path addLineToPoint:CGPointMake(0, 100)]; // 1: [0, 100]
    [path addLineToPoint:CGPointMake(0, 200)]; // 2: [100, 200]
    [path addLineToPoint:CGPointMake(0, 300)]; // 3: [200, 300]
    [path addLineToPoint:CGPointMake(0, 300)]; // 4: ignore this element
    [path addLineToPoint:CGPointMake(0, 300)]; // 5: ignore this element
    [path addLineToPoint:CGPointMake(0, 300)]; // 6: ignore this element
    [path addLineToPoint:CGPointMake(0, 300)]; // 7: ignore this element
    [path addLineToPoint:CGPointMake(0, 400)]; // 8: [300, 400]
    [path addLineToPoint:CGPointMake(0, 0)]; // 9: [400, 0]
    [path closePath];

    CGFloat dist = [path effectiveTDistanceFromElement:4 andTValue:0.005 toElement:6 andTValue:0.995];
    XCTAssertEqualWithAccuracy(dist, 0.0, 0.000001);

    dist = [path effectiveTDistanceFromElement:3 andTValue:0.5 toElement:6 andTValue:0.95];
    XCTAssertEqualWithAccuracy(dist, 0.5, 0.000001);
}
```

in the above, those additional lines to `(0, 300)` don't actually move the path at all. so if we calculate an intersection at the end of element 3 and start of element 6, the path hasn't moved at all between those, so we should consider them equal intersections.

this helps reduce duplicate intersections that are otherwise found when we're calculating element by element.