### PR TITLE
Fix Issue #31: xCode15 import of C++ module appears within extern C

### DIFF
--- a/ClippingBezier/NearestPoint.h
+++ b/ClippingBezier/NearestPoint.h
@@ -9,13 +9,13 @@
 #ifndef __ClippingBezier__NearestPoint__
 #define __ClippingBezier__NearestPoint__
 
+#import <CoreGraphics/CoreGraphics.h>
+
 #if defined __cplusplus
 extern "C" {
 #endif
 
-
 #include <stdio.h>
-#import <CoreGraphics/CoreGraphics.h>
 
 // Bezier functions from git@github.com:erich666/GraphicsGems.git
 CGPoint NearestPointOnCurve(const CGPoint P, const CGPoint *V, double *t);


### PR DESCRIPTION
Apple has changed something in the C / C++ compiler settings when they release xCode 15.0.0 and now, when trying to build our app that uses ClippingBezier as a pod I get this error:
"import of C++ module appears within extern "C" language linkage specification"

This seems to be a similar issue as reported here: https://stackoverflow.com/questions/77113501/xcode-15-compile-error-import-of-c-module-zlib-appears-within-extern-c-la

So I'm applying the suggested fix of doing the import earlier on, before and outside of the `extern "C" {` block.